### PR TITLE
Upgrade `debug` to fix DoS alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "browserify-middleware": "^7.1.0",
     "compression": "^1.6.2",
     "cookie-parser": "~1.4.3",
-    "debug": "~2.2.0",
+    "debug": "^2.6.9",
     "envify": "^4.0.0",
     "express": "~4.14.0",
     "express-https-redirect": "^1.0.0",


### PR DESCRIPTION
Addresses https://nvd.nist.gov/vuln/detail/CVE-2017-16137
via https://github.com/josephfrazier/alley-cheetah-site/network/alert/package.json/debug/open